### PR TITLE
feat: support to force using release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,7 @@ The plugin works based on the following assumptions:
 3. If the git repository is not clean or HEAD does not point to a tag, the project version is a SNAPSHOT version that increases the minor version compared to the last release version
 4. If no release version is configured or the version file is missing, the project version is `1.0.0-SNAPSHOT`
 
+If the environment variable `RELEASE` is set to `true`, the release version is used, even if the repository is not clean or there is no tag.
+This is intended for use cases where the release version was set, but the repository is dirty or no tag was created.
+
 By default the version file is assumed to be the file `version.txt` in the root project.

--- a/src/main/groovy/to/wetransform/gradle/version/VersionPlugin.groovy
+++ b/src/main/groovy/to/wetransform/gradle/version/VersionPlugin.groovy
@@ -44,12 +44,23 @@ class VersionPlugin implements Plugin<Project> {
 
   String determineVersion(Project project, File versionFile, File gitDir) {
     // read version from file
-    if (!versionFile.exists()) {
+    def releaseVersion = null
+    if (versionFile.exists()) {
+      releaseVersion = versionFile.text.trim()
+    }
+
+    //TODO parse/verify version
+
+    if (!releaseVersion) {
       // assume initial snapshot
-      project.logger.info("Version file does not exists, assuming 1.0.0-SNAPSHOT")
+      project.logger.info("Version file does not exist or contains no version, assuming 1.0.0-SNAPSHOT")
       return '1.0.0-SNAPSHOT'
     }
-    def releaseVersion = versionFile.text.trim()
+
+    if ('true'.equalsIgnoreCase(System.getenv('RELEASE'))) {
+      // force release version (e.g if repo is dirty during release in CI)
+      return releaseVersion
+    }
 
     def dirty = false
     def tagOnCurrentCommit = false


### PR DESCRIPTION
...using an environment variable.

Set the environment variable `RELEASE` to `true` to force the release version to be used, even if the repository is dirty or no tag exists at the current commit.